### PR TITLE
updated typescript language server

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -99,7 +99,7 @@ return {
 					"go-debug-adapter",
 
 					-- javascript/typescript & vue
-					"tsserver",
+					"ts_ls",
 					"eslint",
 					"volar",
 					"prettier",


### PR DESCRIPTION
The tsserver typescript language server has been changed to ts_ls so i have updated it to fix the error that mason throws when trying to run nvim